### PR TITLE
Fix issue where login data was not properly cleared after a failed login

### DIFF
--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/LoginFragment.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/LoginFragment.kt
@@ -230,14 +230,14 @@ class LoginFragment : BaseFragment() {
                         Utils(mainActivity).testLoginToken(it)
                     }
                 } catch (e: AsyncPromiseFailure) {
-                    credStore.storeAppToken(null)
+                    mainActivity.logout()
                     showError(true, "Login failed", e.value.toString())
                     return@cancelParallel
                 }
                 moveToLoggedIn()
             }
         }.invokeOnCompletion {
-            progressDialog?.hide()
+            progressDialog.hide()
         }
     }
 

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/QRCodeLoginFragment.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/QRCodeLoginFragment.kt
@@ -246,8 +246,8 @@ class QRCodeLoginFragment : BaseFragment() {
                     }
                 } catch (e: AsyncPromiseFailure) {
                     progressDialog.hide()
-                    credStore.clearLoginData()
                     binding.qrcodeCancelButton.performClick()
+                    mainActivity.logout()
                     showError(true, "Login failed", e.value.toString())
                     return@cancelParallel
                 }


### PR DESCRIPTION
There was an issue was that the client was not destroyed after a login attempt failed, leaving a client active that would still try to reach old endpoints for which logins failed.

Fixed with this PR.