### PR TITLE
Allow user root certificates for verifying server-certificates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:roundIcon="@mipmap/pkg_app_icon"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
-        android:theme="@style/Theme.BabyBuddyWidgets">
+        android:theme="@style/Theme.BabyBuddyWidgets"
+        android:networkSecurityConfig="@xml/network_security_configuration">
 
         <!--
         Disabled for now - does not work right now

--- a/app/src/main/res/xml/network_security_configuration.xml
+++ b/app/src/main/res/xml/network_security_configuration.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Allow user-installed certificates to authenticate a self-hosted server.

Fixes  #63