### PR TITLE
Disable e2e mode on android 35, drop sdk 24 bumping it to 27

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,7 +84,7 @@ android {
 
     defaultConfig {
         applicationId "eu.pkgsoftware.babybuddywidgets"
-        minSdkVersion 24
+        minSdkVersion 27
         targetSdk 35
         versionCode 44
         versionName "2.4.3"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -3,6 +3,7 @@
     <style name="Theme.BabyBuddyWidgets" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
 
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,6 +3,7 @@
     <style name="Theme.BabyBuddyWidgets" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
 
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>


### PR DESCRIPTION
When testing, the updated jackson libraries do not seem to work on android 24 anymore. Next lowest version I was able to verify the app on was android 27.

Temporarily disable Android 35 e2e render mode.