### PR TITLE
Extra diaper options

### DIFF
--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/Constants.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/Constants.kt
@@ -1,5 +1,6 @@
 package eu.pkgsoftware.babybuddywidgets
 
+import androidx.annotation.ColorRes
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -67,11 +68,11 @@ object Constants {
         FeedingMethodEnumValues = m.toMap()
     }
 
-    enum class SolidDiaperColorEnum(var value: Int, var post_name: String) {
-        BLACK(0, "black"),
-        BROWN(1, "brown"),
-        GREEN(2, "green"),
-        YELLOW(3, "yellow");
+    enum class SolidDiaperColorEnum(var value: Int, var post_name: String, @ColorRes var colorResId: Int) {
+        BLACK(0, "black", R.color.diaperBlack),
+        BROWN(1, "brown", R.color.diaperBrown),
+        GREEN(2, "green", R.color.diaperGreen),
+        YELLOW(3, "yellow", R.color.diaperYellow);
 
         companion object {
             @JvmStatic

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/Constants.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/Constants.kt
@@ -66,4 +66,23 @@ object Constants {
         }
         FeedingMethodEnumValues = m.toMap()
     }
+
+    enum class SolidDiaperColorEnum(var value: Int, var post_name: String) {
+        BLACK(0, "black"),
+        BROWN(1, "brown"),
+        GREEN(2, "green"),
+        YELLOW(3, "yellow");
+
+        companion object {
+            @JvmStatic
+            fun byValue(value: Int): SolidDiaperColorEnum {
+                return SolidDiaperColorEnum.entries.first { it.value == value }
+            }
+
+            @JvmStatic
+            fun byPostName(name: String): SolidDiaperColorEnum {
+                return SolidDiaperColorEnum.entries.first { it.post_name == name }
+            }
+        }
+    }
 }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/history/TimelineEntry.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/history/TimelineEntry.kt
@@ -4,6 +4,7 @@ import android.view.MotionEvent
 import android.view.View
 import com.squareup.phrase.Phrase
 import eu.pkgsoftware.babybuddywidgets.BaseFragment
+import eu.pkgsoftware.babybuddywidgets.Constants
 import eu.pkgsoftware.babybuddywidgets.Constants.FeedingMethodEnum
 import eu.pkgsoftware.babybuddywidgets.Constants.FeedingTypeEnum
 import eu.pkgsoftware.babybuddywidgets.DialogCallback
@@ -121,14 +122,36 @@ class TimelineEntry(private val fragment: BaseFragment, private var _entry: Time
 
     private fun configureChange() {
         hideAllSubviews()
+        var amountString = ""
+
         binding.diaperView.visibility = View.VISIBLE
-        val change = entry!! as ChangeEntry
-        binding.diaperWetImage.visibility =
-            if (change!!.wet) View.VISIBLE else View.GONE
-        binding.diaperSolidImage.visibility = if (change.solid) View.VISIBLE else View.GONE
+        (entry as ChangeEntry?)?.let { change ->
+            binding.diaperWetImage.visibility =
+                if (change.wet) View.VISIBLE else View.GONE
+            binding.diaperSolidImage.visibility = if (change.solid) View.VISIBLE else View.GONE
+
+            if (change.color.isNotEmpty()) {
+                binding.diaperColorPreview.visibility = View.VISIBLE
+
+                val colorEnumValue = Constants.SolidDiaperColorEnum.byPostName(change.color)
+                fragment.resources.getColor(colorEnumValue.colorResId, null).let { color ->
+                    binding.diaperColorPreview.setBackgroundColor(color)
+                }
+            } else {
+                binding.diaperColorPreview.visibility = View.GONE
+            }
+
+            if (change.amount != null) {
+                amountString =
+                    Phrase.from(fragment.resources, R.string.diaper_amount_timeline_pattern)
+                        .put("amount", String.format("%.3f", change.amount))
+                    .format().toString()
+                amountString += "\n"
+            }
+        }
         val message = defaultPhraseFields(
-            Phrase.from("{start_date}  {start_time}\n{notes}")
-        ).format().toString().trim { it <= ' ' }
+            Phrase.from("{start_date}  {start_time}\n{amount}{notes}")
+        ).put("amount", amountString).format().toString().trim { it <= ' ' }
         binding.diaperText.text = message.trim { it <= ' ' }
     }
 

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/history/TimelineEntry.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/history/TimelineEntry.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.launch
 import java.io.IOException
 import java.net.MalformedURLException
 import java.text.DateFormat
+import java.text.NumberFormat
 
 
 class TimelineEntry(private val fragment: BaseFragment, private var _entry: TimeEntry?) {
@@ -142,9 +143,12 @@ class TimelineEntry(private val fragment: BaseFragment, private var _entry: Time
             }
 
             if (change.amount != null) {
+                val nf = NumberFormat.getInstance()
+                nf.maximumIntegerDigits = 3
+                nf.minimumFractionDigits = 0
                 amountString =
                     Phrase.from(fragment.resources, R.string.diaper_amount_timeline_pattern)
-                        .put("amount", String.format("%.3f", change.amount))
+                        .put("amount", nf.format(change.amount)).format().toString()
                     .format().toString()
                 amountString += "\n"
             }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
@@ -274,7 +274,10 @@ abstract class GenericLoggingController(
 data class DiaperDataRecord(
     @JsonProperty("wet") val wet: Boolean,
     @JsonProperty("solid") val solid: Boolean,
-    @JsonProperty("note") val note: String
+    @JsonProperty("note") val note: String,
+    @JsonProperty("extra_options_open") val extraOptionsOpen: Boolean,
+    @JsonProperty("color") val color: String?,
+    @JsonProperty("amount") val amount: Double?
 )
 
 class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : LoggingControls(childId) {
@@ -315,6 +318,7 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
             wetLogic.state = it.wet
             solidLogic.state = it.solid
             noteEditor.setText(it.note)
+            extraOptionsLogic.state = it.extraOptionsOpen
         }
 
         updateSaveEnabledState()
@@ -330,7 +334,12 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
 
     override fun storeStateForSuspend() {
         val ddr = DiaperDataRecord(
-            wetLogic.state, solidLogic.state, noteEditor.text.toString()
+            wetLogic.state,
+            solidLogic.state,
+            noteEditor.text.toString(),
+            extraOptionsLogic.state,
+            null,
+            null
         )
         fragment.mainActivity.storage.child(childId, "diaper", ddr)
     }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
@@ -288,6 +288,12 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
     val solidLogic = SwitchButtonLogic(
         bindings.solidDisabledButton, bindings.solidEnabledButton, false
     )
+    val extraOptionsLogic = SwitchButtonLogic(
+        bindings.openExtraOptions,
+        bindings.closeExtraOptions,
+        false
+    )
+
     val noteEditor = bindings.noteEditor
 
     init {
@@ -296,6 +302,13 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
         }
         solidLogic.addStateListener { _, _ ->
             updateSaveEnabledState()
+        }
+        extraOptionsLogic.addStateListener { state, _ ->
+            bindings.extraOptionsList.visibility = if (state) {
+                View.VISIBLE
+            } else {
+                View.GONE
+            }
         }
 
         fragment.mainActivity.storage.child<DiaperDataRecord>(childId, "diaper")?.let {
@@ -865,9 +878,10 @@ class LoggingButtonController(
                 fragment.mainActivity.scope.launch {
                     try {
                         timerModificationsBlocker.register {
-                            val newTimer = AsyncPromise.call<Timer, TranslatedException> { promise ->
-                                timerControl.startTimer(it, promise)
-                            }
+                            val newTimer =
+                                AsyncPromise.call<Timer, TranslatedException> { promise ->
+                                    timerControl.startTimer(it, promise)
+                                }
                             controller.updateTimer(newTimer)
                         }
                     }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
@@ -320,6 +320,8 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
             }
         }
 
+        bindings.amountEditor.allowNull = true
+
         val colorValues = listOf(
             Constants.SolidDiaperColorEnum.BLACK,
             Constants.SolidDiaperColorEnum.BROWN,
@@ -339,7 +341,15 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
             solidLogic.state = it.solid
             noteEditor.setText(it.note)
             extraOptionsLogic.state = it.extraOptionsOpen
-            diaperColor = it.color?.let { Constants.SolidDiaperColorEnum.byPostName(it) }
+            diaperColor = it.color?.let {
+                try {
+                    Constants.SolidDiaperColorEnum.byPostName(it)
+                }
+                catch (_: NoSuchElementException) {
+                    null
+                }
+            }
+            bindings.amountEditor.value = it.amount
         }
 
         updateSaveEnabledState()
@@ -378,7 +388,7 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
             noteEditor.text.toString(),
             extraOptionsLogic.state,
             diaperColor?.post_name,
-            null
+            bindings.amountEditor.value,
         )
         fragment.mainActivity.storage.child(childId, "diaper", ddr)
     }
@@ -387,6 +397,9 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
         noteEditor.setText("")
         wetLogic.state = false
         solidLogic.state = false
+        extraOptionsLogic.state = false
+        diaperColor = null
+        bindings.amountEditor.value = null
     }
 
     suspend override fun save(): TimeEntry {

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
@@ -404,6 +404,9 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
     }
 
     suspend override fun save(): TimeEntry {
+        val color = if (extraOptionsLogic.state) diaperColor?.post_name else null
+        val amount = if (extraOptionsLogic.state) bindings.amountEditor.value else null
+
         return fragment.mainActivity.client.v2client.createEntry(
             ChangeEntry::class,
             ChangeEntry(
@@ -413,8 +416,8 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
                 _notes = noteEditor.text.toString(),
                 wet = wetLogic.state,
                 solid = solidLogic.state,
-                color = diaperColor?.post_name ?: "",
-                amount = bindings.amountEditor.value
+                color = color ?: "",
+                amount = amount
             )
         )
     }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
@@ -353,6 +353,7 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
         }
 
         updateSaveEnabledState()
+        updateColorButtons()
     }
 
     private fun updateColorButtons() {
@@ -412,8 +413,8 @@ class DiaperLoggingController(val fragment: BaseFragment, childId: Int) : Loggin
                 _notes = noteEditor.text.toString(),
                 wet = wetLogic.state,
                 solid = solidLogic.state,
-                color = "",
-                amount = null
+                color = diaperColor?.post_name ?: "",
+                amount = bindings.amountEditor.value
             )
         )
     }

--- a/app/src/main/res/drawable/collapse_button.xml
+++ b/app/src/main/res/drawable/collapse_button.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="64dp" android:viewportHeight="52.917" android:viewportWidth="52.917" android:width="64dp">
+      
+    <path android:fillColor="#FF000000" android:pathData="m17.092,24.25h18.732v4.417H17.092Z" android:strokeWidth="0.264583"/>
+    
+</vector>

--- a/app/src/main/res/drawable/expand_button.xml
+++ b/app/src/main/res/drawable/expand_button.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="64dp" android:viewportHeight="52.917" android:viewportWidth="52.917" android:width="64dp">
+      
+    <path android:fillColor="#FF000000" android:pathData="M9.165,24.241H23.234V9.681h4.908V24.241h14.478v4.335H28.142v14.478h-4.908V28.576H9.165Z" android:strokeWidth="0.264583"/>
+    
+</vector>

--- a/app/src/main/res/layout/diaper_logging_entry.xml
+++ b/app/src/main/res/layout/diaper_logging_entry.xml
@@ -171,16 +171,137 @@
             android:id="@+id/extraOptionsList"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
             android:orientation="vertical"
+            android:padding="8dp"
             android:visibility="gone"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/noteEditor">
+            app:layout_constraintTop_toBottomOf="@id/noteEditor"
+            tools:visibility="visible">
 
             <TextView
-                android:id="@+id/textView"
+                android:id="@+id/diaperColorLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
-                android:text="@string/diaper_extra_options" />
+                android:layout_marginBottom="8dp"
+                android:text="@string/diaper_color_label"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+            <eu.pkgsoftware.babybuddywidgets.widgets.AutoHGrid
+                android:id="@+id/diaperColorGrid"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <ImageView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        app:srcCompat="@android:drawable/arrow_down_float" />
+
+                    <ImageButton
+                        android:layout_width="64dp"
+                        android:layout_height="64dp"
+                        android:src="@color/diaperBlack" />
+
+                    <ImageView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        app:srcCompat="@android:drawable/arrow_up_float" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <ImageView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        app:srcCompat="@android:drawable/arrow_down_float" />
+
+                    <ImageButton
+                        android:layout_width="64dp"
+                        android:layout_height="64dp"
+                        android:src="@color/diaperBrown" />
+
+                    <ImageView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        app:srcCompat="@android:drawable/arrow_up_float" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <ImageView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        app:srcCompat="@android:drawable/arrow_down_float" />
+
+                    <ImageButton
+                        android:layout_width="64dp"
+                        android:layout_height="64dp"
+                        android:src="@color/diaperGreen" />
+
+                    <ImageView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        app:srcCompat="@android:drawable/arrow_up_float" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <ImageView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        app:srcCompat="@android:drawable/arrow_down_float" />
+
+                    <ImageButton
+                        android:layout_width="64dp"
+                        android:layout_height="64dp"
+                        android:src="@color/diaperYellow" />
+
+                    <ImageView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        app:srcCompat="@android:drawable/arrow_up_float" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <ImageView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        app:srcCompat="@android:drawable/arrow_down_float" />
+
+                    <ImageButton
+                        android:layout_width="64dp"
+                        android:layout_height="64dp"
+                        android:src="@android:drawable/ic_menu_close_clear_cancel" />
+
+                    <ImageView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        app:srcCompat="@android:drawable/arrow_up_float" />
+                </LinearLayout>
+            </eu.pkgsoftware.babybuddywidgets.widgets.AutoHGrid>
         </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/diaper_logging_entry.xml
+++ b/app/src/main/res/layout/diaper_logging_entry.xml
@@ -172,7 +172,6 @@
             android:id="@+id/extraOptionsList"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
             android:orientation="vertical"
             android:padding="8dp"
             android:visibility="gone"
@@ -180,144 +179,155 @@
             app:layout_constraintTop_toBottomOf="@id/noteEditor"
             tools:visibility="visible">
 
-            <TextView
-                android:id="@+id/diaperColorLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:layout_marginBottom="8dp"
-                android:text="@string/diaper_color_label"
-                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
-
-            <eu.pkgsoftware.babybuddywidgets.widgets.AutoHGrid
-                android:id="@+id/diaperColorGrid"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
-
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:orientation="vertical">
-
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        app:srcCompat="@android:drawable/arrow_down_float" />
-
-                    <ImageButton
-                        android:layout_width="64dp"
-                        android:layout_height="64dp"
-                        android:src="@color/diaperBlack" />
-
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        app:srcCompat="@android:drawable/arrow_up_float" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:orientation="vertical">
-
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        app:srcCompat="@android:drawable/arrow_down_float" />
-
-                    <ImageButton
-                        android:layout_width="64dp"
-                        android:layout_height="64dp"
-                        android:src="@color/diaperBrown" />
-
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        app:srcCompat="@android:drawable/arrow_up_float" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:orientation="vertical">
-
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        app:srcCompat="@android:drawable/arrow_down_float" />
-
-                    <ImageButton
-                        android:layout_width="64dp"
-                        android:layout_height="64dp"
-                        android:src="@color/diaperGreen" />
-
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        app:srcCompat="@android:drawable/arrow_up_float" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:orientation="vertical">
-
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        app:srcCompat="@android:drawable/arrow_down_float" />
-
-                    <ImageButton
-                        android:layout_width="64dp"
-                        android:layout_height="64dp"
-                        android:src="@color/diaperYellow" />
-
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        app:srcCompat="@android:drawable/arrow_up_float" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:orientation="vertical">
-
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        app:srcCompat="@android:drawable/arrow_down_float" />
-
-                    <ImageButton
-                        android:layout_width="64dp"
-                        android:layout_height="64dp"
-                        android:src="@android:drawable/ic_menu_close_clear_cancel" />
-
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        app:srcCompat="@android:drawable/arrow_up_float" />
-                </LinearLayout>
-            </eu.pkgsoftware.babybuddywidgets.widgets.AutoHGrid>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="16dp"
-                android:text="@string/diaper_amount_title"
-                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
-
-            <eu.pkgsoftware.babybuddywidgets.widgets.HorizontalDecIncEditor
-                android:id="@+id/amountEditor"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_weight="1" />
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+                <TextView
+                    android:id="@+id/diaperColorLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/diaper_color_label"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                <eu.pkgsoftware.babybuddywidgets.widgets.AutoHGrid
+                    android:id="@+id/diaperColorGrid"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:equalizeRowWidths="true">
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            app:srcCompat="@android:drawable/arrow_down_float" />
+
+                        <ImageButton
+                            android:layout_width="54dp"
+                            android:layout_height="54dp"
+                            android:src="@color/diaperBlack" />
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            app:srcCompat="@android:drawable/arrow_up_float" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            app:srcCompat="@android:drawable/arrow_down_float" />
+
+                        <ImageButton
+                            android:layout_width="54dp"
+                            android:layout_height="54dp"
+                            android:src="@color/diaperBrown" />
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            app:srcCompat="@android:drawable/arrow_up_float" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            app:srcCompat="@android:drawable/arrow_down_float" />
+
+                        <ImageButton
+                            android:layout_width="54dp"
+                            android:layout_height="54dp"
+                            android:src="@color/diaperGreen" />
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            app:srcCompat="@android:drawable/arrow_up_float" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            app:srcCompat="@android:drawable/arrow_down_float" />
+
+                        <ImageButton
+                            android:layout_width="54dp"
+                            android:layout_height="54dp"
+                            android:src="@color/diaperYellow" />
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            app:srcCompat="@android:drawable/arrow_up_float" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            app:srcCompat="@android:drawable/arrow_down_float" />
+
+                        <ImageButton
+                            android:layout_width="54dp"
+                            android:layout_height="54dp"
+                            android:src="@android:drawable/ic_menu_close_clear_cancel" />
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            app:srcCompat="@android:drawable/arrow_up_float" />
+                    </LinearLayout>
+                </eu.pkgsoftware.babybuddywidgets.widgets.AutoHGrid>
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="16dp"
+                    android:text="@string/diaper_amount_title"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                <eu.pkgsoftware.babybuddywidgets.widgets.HorizontalDecIncEditor
+                    android:id="@+id/amountEditor"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+            </LinearLayout>
         </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/diaper_logging_entry.xml
+++ b/app/src/main/res/layout/diaper_logging_entry.xml
@@ -58,8 +58,8 @@
 
         <ImageButton
             android:id="@+id/sendButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
             android:layout_margin="4dp"
             android:layout_marginEnd="277dp"
             android:layout_weight="0"
@@ -302,6 +302,21 @@
                         app:srcCompat="@android:drawable/arrow_up_float" />
                 </LinearLayout>
             </eu.pkgsoftware.babybuddywidgets.widgets.AutoHGrid>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/diaper_amount_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+            <eu.pkgsoftware.babybuddywidgets.widgets.HorizontalDecIncEditor
+                android:id="@+id/amountEditor"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_weight="1" />
         </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/diaper_logging_entry.xml
+++ b/app/src/main/res/layout/diaper_logging_entry.xml
@@ -142,13 +142,14 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="32dp"
             android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="@+id/solidButtonGroup"
             app:layout_constraintStart_toEndOf="@+id/solidButtonGroup"
             app:layout_constraintTop_toTopOf="parent">
 
             <ImageButton
                 android:id="@+id/closeExtraOptions"
-                android:layout_width="64dp"
-                android:layout_height="64dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_weight="0"
                 android:scaleType="fitCenter"
                 android:src="@drawable/collapse_button"
@@ -158,8 +159,8 @@
 
             <ImageButton
                 android:id="@+id/openExtraOptions"
-                android:layout_width="64dp"
-                android:layout_height="64dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_weight="0"
                 android:scaleType="fitCenter"
                 android:src="@drawable/expand_button"

--- a/app/src/main/res/layout/diaper_logging_entry.xml
+++ b/app/src/main/res/layout/diaper_logging_entry.xml
@@ -65,7 +65,7 @@
             android:layout_weight="0"
             android:visibility="visible"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/noteEditor"
+            app:layout_constraintTop_toBottomOf="@+id/extraOptionsList"
             app:srcCompat="@android:drawable/ic_menu_save" />
 
         <LinearLayout
@@ -135,6 +135,54 @@
                 android:visibility="visible"
                 app:tint="@color/fixed_color_button_text_color" />
         </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/extraOptionsGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:orientation="vertical"
+            app:layout_constraintStart_toEndOf="@+id/solidButtonGroup"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageButton
+                android:id="@+id/closeExtraOptions"
+                android:layout_width="64dp"
+                android:layout_height="64dp"
+                android:layout_weight="0"
+                android:scaleType="fitCenter"
+                android:src="@drawable/collapse_button"
+                android:tintMode="src_in"
+                android:visibility="gone"
+                app:tint="?android:attr/textColorSecondary" />
+
+            <ImageButton
+                android:id="@+id/openExtraOptions"
+                android:layout_width="64dp"
+                android:layout_height="64dp"
+                android:layout_weight="0"
+                android:scaleType="fitCenter"
+                android:src="@drawable/expand_button"
+                android:tintMode="src_in"
+                android:visibility="visible" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/extraOptionsList"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/noteEditor">
+
+            <TextView
+                android:id="@+id/textView"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:text="@string/diaper_extra_options" />
+        </LinearLayout>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/app/src/main/res/layout/pumping_logging_entry.xml
+++ b/app/src/main/res/layout/pumping_logging_entry.xml
@@ -67,7 +67,7 @@
         <ImageButton
             android:id="@+id/sendButton"
             android:layout_width="56dp"
-            android:layout_height="wrap_content"
+            android:layout_height="56dp"
             android:layout_margin="4dp"
             android:layout_weight="0"
             android:visibility="visible"

--- a/app/src/main/res/layout/timeline_item.xml
+++ b/app/src/main/res/layout/timeline_item.xml
@@ -176,6 +176,17 @@
                 app:tint="?android:attr/textColorSecondary"
                 app:tintMode="src_in" />
 
+            <ImageView
+                android:id="@+id/diaperColorPreview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:minHeight="16dp"
+                android:minWidth="16dp"
+                android:layout_marginLeft="8dp"
+                android:background="@color/black"
+                app:tintMode="src_in" />
+
             <TextView
                 android:id="@+id/diaperText"
                 android:layout_width="wrap_content"

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -19,6 +19,12 @@
         <item>Ouder voeding</item>
         <item>Zelf voeding</item>
     </array>
+    <array name="solidDiaperColors">
+        <item>Zwart</item>
+        <item>Bruin</item>
+        <item>Groen</item>
+        <item>Geel</item>
+    </array>
 
     <string name="app_name">Baby Buddy</string>
 
@@ -93,6 +99,7 @@
 
     <!-- Generic store error -->
     <string name="activity_notes_hint">Notities</string>
+    <string name="diaper_amount_title">Hoeveelheid</string>
     <string name="activity_store_failure_message">Kon activiteit niet opslaan</string>
     <string name="activity_store_failure_server_error">{message}\n\nServer meldt: {server_message}</string>
     <string name="activity_store_failure_server_error_generic_ioerror">Fout bij opslaan van activiteit</string>
@@ -126,6 +133,7 @@
     <string name="history_loading_timeline_entry_failed_with_error">Kan {activity} gegevens niet laden: {error}</string>
 
     <!-- QR Code Login -->
+    <string name="history_amount_timeline_pattern">Hoeveelheid: {amount}</string>
     <string name="login_qrcode_camera_access_needed_dialog_title">Cameratoegang nodig</string>
     <string name="login_qrcode_camera_access_needed_dialog_body">
         Om de QR-codescanner te gebruiken, heeft de app toegang nodig tot de camera van uw apparaat.\n\nAls alternatief kunt u ervoor kiezen om het inlogscherm te gebruiken en server, gebruikersnaam en wachtwoord handmatig in te voeren.
@@ -196,4 +204,5 @@
         <item>Licht</item>
         <item>Donker</item>
     </array>
+    <string name="diaper_color_label">Kleur</string>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -35,4 +35,9 @@
     <color name="light_blue_400">#FF29B6F6</color>
     <color name="gray_400">#FFBDBDBD</color>
     <color name="gray_600">#FF757575</color>
+
+    <color name="diaperBlack">#FF000000</color>
+    <color name="diaperBrown">#DB8200</color>
+    <color name="diaperGreen">#FF00A900</color>
+    <color name="diaperYellow">#FFD7D700</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,7 +106,7 @@
     <string name="activity_notes_hint">Notes</string>
 
     <!-- Store activity: Diaper -->
-    <string name="diaper_color_label">Diaper color</string>
+    <string name="diaper_color_label">Color</string>
     <string name="diaper_amount_title">Amount</string>
     <string name="diaper_amount_timeline_pattern">Amount: {amount}</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,12 @@
         <item>Parent fed</item>
         <item>Self fed</item>
     </array>
+    <array name="solidDiaperColors">
+        <item>Black</item>
+        <item>Brown</item>
+        <item>Green</item>
+        <item>Yellow</item>
+    </array>
 
     <string name="app_name">Baby Buddy</string>
 
@@ -100,7 +106,7 @@
     <string name="activity_notes_hint">Notes</string>
 
     <!-- Store activity: Diaper -->
-    <string name="diaper_extra_options">Extra options</string>
+    <string name="diaper_color_label">Diaper color</string>
 
     <!-- Generic store error -->
     <string name="activity_store_failure_message">Could not store activity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,7 +108,6 @@
     <!-- Store activity: Diaper -->
     <string name="diaper_color_label">Color</string>
     <string name="diaper_amount_title">Amount</string>
-    <string name="diaper_amount_timeline_pattern">Amount: {amount}</string>
 
     <!-- Generic store error -->
     <string name="activity_store_failure_message">Could not store activity</string>
@@ -146,6 +145,8 @@
     <string name="history_delete_question_cancel_button">Cancel</string>
     <string name="history_loading_timeline_entry_failed">Failed to load {activity} entries.</string>
     <string name="history_loading_timeline_entry_failed_with_error">Failed to load {activity} entries: {error}</string>
+
+    <string name="history_amount_timeline_pattern">Amount: {amount}</string>
 
     <!-- QR Code Login -->
     <string name="login_qrcode_camera_access_needed_dialog_title">Camera access needed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,13 +91,16 @@
     <!-- Generic logged in -->
     <string name="logged_in_no_children_found">(No children found)</string>
 
-    <!--- Store activities -->
+    <!-- Store activities -->
     <string name="diaper_title">Diaper</string>
     <string name="error_storing_activity_failed_title">Could not store activity</string>
     <string name="error_storing_activity_unsupported">Unsupported activity</string>
     <string name="popup_message_storing">Storing {activity} …</string>
 
     <string name="activity_notes_hint">Notes</string>
+
+    <!-- Store activity: Diaper -->
+    <string name="diaper_extra_options">Extra options</string>
 
     <!-- Generic store error -->
     <string name="activity_store_failure_message">Could not store activity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,7 @@
     <!-- Store activity: Diaper -->
     <string name="diaper_color_label">Diaper color</string>
     <string name="diaper_amount_title">Amount</string>
+    <string name="diaper_amount_timeline_pattern">Amount: {amount}</string>
 
     <!-- Generic store error -->
     <string name="activity_store_failure_message">Could not store activity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
 
     <!-- Store activity: Diaper -->
     <string name="diaper_color_label">Diaper color</string>
+    <string name="diaper_amount_title">Amount</string>
 
     <!-- Generic store error -->
     <string name="activity_store_failure_message">Could not store activity</string>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.8.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Dec 30 21:54:35 CET 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/resources/collapse-button.svg
+++ b/resources/collapse-button.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200"
+   height="200"
+   viewBox="0 0 52.916665 52.916668"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   sodipodi:docname="collapse-button.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     units="px"
+     width="200px"
+     inkscape:zoom="1.5073233"
+     inkscape:cx="110.129"
+     inkscape:cy="79.943038"
+     inkscape:window-width="1240"
+     inkscape:window-height="1080"
+     inkscape:window-x="244"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill-rule:evenodd;fill:context-stroke;stroke:context-stroke;stroke-width:1.0pt"
+         d="M 5.77,0.0 L -2.88,5.0 L -2.88,-5.0 L 5.77,0.0 z "
+         id="path1004" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutS"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="TriangleOutS"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2)"
+         style="fill-rule:evenodd;fill:context-stroke;stroke:context-stroke;stroke-width:1.0pt"
+         d="M 5.77,0.0 L -2.88,5.0 L -2.88,-5.0 L 5.77,0.0 z "
+         id="path1007" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutL"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="TriangleOutL"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.8)"
+         style="fill-rule:evenodd;fill:context-stroke;stroke:context-stroke;stroke-width:1.0pt"
+         d="M 5.77,0.0 L -2.88,5.0 L -2.88,-5.0 L 5.77,0.0 z "
+         id="path1001" />
+    </marker>
+    <marker
+       style="overflow:visible;"
+       id="Arrow2Mend"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.6) rotate(180) translate(0,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="stroke:context-stroke;fill-rule:evenodd;fill:context-stroke;stroke-width:0.62500000;stroke-linejoin:round;"
+         id="path886" />
+    </marker>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       d="m 17.092463,24.249789 h 18.731742 v 4.417092 H 17.092463 Z"
+       id="text1"
+       style="font-size:81.798px;line-height:1.25;font-family:Caladea;-inkscape-font-specification:Caladea;stroke-width:0.264583"
+       aria-label="-" />
+  </g>
+</svg>

--- a/resources/expand-button.svg
+++ b/resources/expand-button.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200"
+   height="200"
+   viewBox="0 0 52.916665 52.916668"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   sodipodi:docname="expand-button.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     units="px"
+     width="200px"
+     inkscape:zoom="1.5073233"
+     inkscape:cx="110.12899"
+     inkscape:cy="79.943035"
+     inkscape:window-width="1240"
+     inkscape:window-height="1080"
+     inkscape:window-x="2334"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.4)"
+         style="fill-rule:evenodd;fill:context-stroke;stroke:context-stroke;stroke-width:1.0pt"
+         d="M 5.77,0.0 L -2.88,5.0 L -2.88,-5.0 L 5.77,0.0 z "
+         id="path1004" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutS"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="TriangleOutS"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2)"
+         style="fill-rule:evenodd;fill:context-stroke;stroke:context-stroke;stroke-width:1.0pt"
+         d="M 5.77,0.0 L -2.88,5.0 L -2.88,-5.0 L 5.77,0.0 z "
+         id="path1007" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutL"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="TriangleOutL"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.8)"
+         style="fill-rule:evenodd;fill:context-stroke;stroke:context-stroke;stroke-width:1.0pt"
+         d="M 5.77,0.0 L -2.88,5.0 L -2.88,-5.0 L 5.77,0.0 z "
+         id="path1001" />
+    </marker>
+    <marker
+       style="overflow:visible;"
+       id="Arrow2Mend"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.6) rotate(180) translate(0,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="stroke:context-stroke;fill-rule:evenodd;fill:context-stroke;stroke-width:0.62500000;stroke-linejoin:round;"
+         id="path886" />
+    </marker>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       d="M 9.1650226,24.240603 H 23.234278 V 9.6805593 h 4.90788 V 24.240603 h 14.478245 v 4.335294 H 28.142158 v 14.478245 h -4.90788 V 28.575897 H 9.1650226 Z"
+       id="text1"
+       style="font-size:81.798px;line-height:1.25;font-family:Caladea;-inkscape-font-specification:Caladea;stroke-width:0.264583"
+       aria-label="+" />
+  </g>
+</svg>


### PR DESCRIPTION
- Implement amount and color widgets for diaper registrations:

![image](https://github.com/user-attachments/assets/f986a92c-dd17-4660-9393-3f829ec4d595)

- Implement amount previews in event history for all events with an "amount".
- Implement color previews for diapers (if set)

![image](https://github.com/user-attachments/assets/00f7d593-5c4b-43dc-9784-6649763f76bb)

Fixes  #42