### PR TITLE
Fix feedings being shown as "tummy time"

### DIFF
--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
@@ -526,7 +526,7 @@ class FeedingLoggingController(
     fragment: BaseFragment,
     childId: Int,
     timerControl: TimerControlInterface
-) : GenericLoggingController(fragment, childId, timerControl, TummyTimeEntry::class) {
+) : GenericLoggingController(fragment, childId, timerControl, FeedingEntry::class) {
     val feedingBinding = FeedingLoggingEntryBinding.inflate(fragment.layoutInflater)
 
     override val uiCurrentTimerTime = feedingBinding.currentTimerTime


### PR DESCRIPTION
Fix the feeding timer controller to use `FeedingEntry` instead of `TummyTimeEntry`.

Fixes #92
